### PR TITLE
fix: code improvements

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
   code:
     description: "The expected status code"
     required: false
-    default: 200
+    default: '200'
   timeout:
     description: "Timeout before giving up in seconds"
     required: false

--- a/action.yml
+++ b/action.yml
@@ -16,11 +16,11 @@ inputs:
   timeout:
     description: "Timeout before giving up in seconds"
     required: false
-    default: 300
+    default: '300'
   interval:
     description: "Interval between polling in seconds"
     required: false
-    default: 2
+    default: '2'
   username:
     description: "Basic auth username"
     required: false
@@ -37,10 +37,11 @@ runs:
   steps:
     - id: main
       run: |
-        timeout ${{inputs.timeout }} ${GITHUB_ACTION_PATH}/main.sh \
+        ${GITHUB_ACTION_PATH}/main.sh \
         --code="${{ inputs.code }}" \
         --url="${{ inputs.url }}" \
         --username="${{ inputs.username }}" \
         --password="${{ inputs.password }}" \
         --interval="${{ inputs.interval }}"\
+        --timeout="${{ inputs.timeout }}"\
       shell: bash

--- a/main.sh
+++ b/main.sh
@@ -31,7 +31,11 @@ while test $# -gt 0; do
       shift
       ;;
     --interval*)
-      interval=`echo $1 | sed -e 's/^[^=]*=//g'`
+      interval=$(echo "$1" | sed -e 's/^[^=]*=//g')
+      shift
+      ;;
+    --timeout*)
+      timeout=$(echo "$1" | sed -e 's/^[^=]*=//g')
       shift
       ;;
     *)
@@ -41,6 +45,11 @@ while test $# -gt 0; do
 done
 
 code="${code:-200}"
+interval="${interval//[^0-9]/}"
+interval="${interval:-10}"
+timeout="${timeout//[^0-9]/}"
+timeout="${timeout:-300}"
+
 auth_args=()
 if [[ -n "$username" ]]; then
   auth_args=(--user "$username:$password")
@@ -48,17 +57,22 @@ if [[ -n "$username" ]]; then
 fi
 
 function poll_status {
-  while true;
-  do
+  local elapsed=0
+  while true; do
     STATUS_CODE=$(curl -A "Web Check" -s --location-trusted --connect-timeout 3 -w "%{http_code}\n" "${auth_args[@]}" "$url" -o /dev/null)
     echo "$(date +%H:%M:%S): The status code is $STATUS_CODE"
     if [[ "$STATUS_CODE" == "$code" ]]; then
       echo "success"
       exit 0
     fi
-    sleep $interval;
+    if (( elapsed >= timeout )); then
+      echo "Timeout after ${timeout}s waiting for status $code on ${url%\?*}"
+      exit 1
+    fi
+    sleep "$interval"
+    (( elapsed += interval ))
   done
 }
 
-printf "\nPolling '${url%\?*}' every $interval seconds, until status is '200'\n"
+printf "\nPolling '${url%\?*}' every ${interval}s, timeout ${timeout}s, until status is '${code}'\n"
 poll_status

--- a/main.sh
+++ b/main.sh
@@ -40,14 +40,16 @@ while test $# -gt 0; do
   esac
 done
 
+auth_args=()
+if [[ -n "$username" ]]; then
+  auth_args=(--user "$username:$password")
+  echo "Basic Authentication enabled."
+fi
+
 function poll_status {
   while true;
   do
-    auth=""
-    if [[ "$username" != "" ]]; then
-      auth="-u $username:$password"
-    fi;
-    STATUS_CODE=`curl -A "Web Check" -sL --connect-timeout 3 -w "%{http_code}\n" $auth $url -o /dev/null`
+    STATUS_CODE=$(curl -A "Web Check" -s --location-trusted --connect-timeout 3 -w "%{http_code}\n" "${auth_args[@]}" "$url" -o /dev/null)
     echo "$(date +%H:%M:%S): The status code is $STATUS_CODE";
     if [[ "$STATUS_CODE" == "200" ]]; then
           echo "success";

--- a/main.sh
+++ b/main.sh
@@ -8,26 +8,29 @@ while test $# -gt 0; do
       echo "./main.sh [options]"
       echo " "
       echo "options:"
-      echo "-h, --help           Show brief help"
-      echo "--url=URL            url to poll"
-      echo "--interval=INTERVAL  Interval between each call, in seconds"
-      echo "--timeout=TIMEOUT    Timeout before stop polling, in seconds"
+      echo "-h, --help                    Show brief help"
+      echo "--url=URL                     URL to poll"
+      echo "--code=CODE                   Expected HTTP status code (default: 200)"
+      echo "--username=USERNAME           Basic Auth username"
+      echo "--password=PASSWORD           Basic Auth password"
+      echo "--interval=INTERVAL           Interval between each call, in seconds"
+      echo "--timeout=TIMEOUT             Timeout before stop polling, in seconds"
       exit 0
       ;;
     --url*)
-      url=`echo $1 | sed -e 's/^[^=]*=//g'`
+      url=$(echo "$1" | sed -e 's/^[^=]*=//g')
       shift
       ;;
     --code*)
-      code=`echo $1 | sed -e 's/^[^=]*=//g'`
+      code=$(echo "$1" | sed -e 's/^[^=]*=//g')
       shift
       ;;
     --username*)
-      username=`echo $1 | sed -e 's/^[^=]*=//g'`
+      username=$(echo "$1" | sed -e 's/^[^=]*=//g')
       shift
       ;;
     --password*)
-      password=`echo $1 | sed -e 's/^[^=]*=//g'`
+      password=$(echo "$1" | sed -e 's/^[^=]*=//g')
       shift
       ;;
     --interval*)

--- a/main.sh
+++ b/main.sh
@@ -40,6 +40,7 @@ while test $# -gt 0; do
   esac
 done
 
+code="${code:-200}"
 auth_args=()
 if [[ -n "$username" ]]; then
   auth_args=(--user "$username:$password")
@@ -50,12 +51,11 @@ function poll_status {
   while true;
   do
     STATUS_CODE=$(curl -A "Web Check" -s --location-trusted --connect-timeout 3 -w "%{http_code}\n" "${auth_args[@]}" "$url" -o /dev/null)
-    echo "$(date +%H:%M:%S): The status code is $STATUS_CODE";
-    if [[ "$STATUS_CODE" == "200" ]]; then
-          echo "success";
-          exit 0;
-        break;
-    fi;
+    echo "$(date +%H:%M:%S): The status code is $STATUS_CODE"
+    if [[ "$STATUS_CODE" == "$code" ]]; then
+      echo "success"
+      exit 0
+    fi
     sleep $interval;
   done
 }


### PR DESCRIPTION
## Add basic auth support and refactor curl

- use a function to generate the auth args
- the auth values were unquoted and could break the command
- update curl flags to use `--location-trusted` so that redirects do not loose the auth credentials

Resolves: #2

## fix: checking for other status codes 

remove the fixed status code and use the variable or default value instead

Resolves: #4

## fix: interval setting and timeout didnt work propertly 

- fix the timeout functionality
- remove non-numeric characters from the values
- abort the command if the timeout is reached

Resolves: #1
Resolves: #3

## fix: reading of the arguments 

- add missing arguments to the help block
- optimize the reading of the arguments